### PR TITLE
Code to remove reference check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.4.1 Release on 2019-04-03.
+
+* Fixed issue with models that are not reference. [#136](https://github.com/Azure/openapi-diff/pull/136)
+
 ## 0.1.13 Released on 2019-01-03.
 
 * Fixed security vulnerability issue reported in github. [#121](https://github.com/Azure/openapi-diff/pull/121)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-
+ 
 ## 0.4.1 Release on 2019-04-03.
 
 * Fixed issue with models that are not reference. [#136](https://github.com/Azure/openapi-diff/pull/136)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 ## 0.4.1 Release on 2019-04-03.
 
 * Fixed issue with models that are not reference. [#136](https://github.com/Azure/openapi-diff/pull/136)

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/new/format_check_01.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/new/format_check_01.json
@@ -1,0 +1,22 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "2018-01-01",
+        "title": "Schema of Azure Storage events published to Azure Event Grid",
+        "description": "Describes the schema of the Azure Storage events published to Azure Event Grid. This corresponds to the Data property of an EventGridEvent."
+    },
+    "paths": {},
+    "definitions": {
+        "StorageBlobCreatedEventData": {
+            "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Storage.BlobCreated event.",
+            "type": "object",
+            "properties": {
+                "contentLength": {
+                    "description": "The size of the blob in bytes. This is the same as what would be returned in the Content-Length header from the blob.",
+                    "type": "integer",
+                    "format": "int64"
+                }
+            }
+        }
+    }
+}

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/new/format_check_02.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/new/format_check_02.json
@@ -1,0 +1,21 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "2018-01-01",
+        "title": "Schema of Azure Storage events published to Azure Event Grid",
+        "description": "Describes the schema of the Azure Storage events published to Azure Event Grid. This corresponds to the Data property of an EventGridEvent."
+    },
+    "paths": {},
+    "definitions": {
+        "StorageBlobCreatedEventData": {
+            "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Storage.BlobCreated event.",
+            "type": "object",
+            "properties": {
+                "contentLength": {
+                    "description": "The size of the blob in bytes. This is the same as what would be returned in the Content-Length header from the blob.",
+                    "type": "integer"
+                }
+            }
+        }
+    }
+}

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/format_check_01.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/format_check_01.json
@@ -1,0 +1,21 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "2018-01-01",
+        "title": "Schema of Azure Storage events published to Azure Event Grid",
+        "description": "Describes the schema of the Azure Storage events published to Azure Event Grid. This corresponds to the Data property of an EventGridEvent."
+    },
+    "paths": {},
+    "definitions": {
+        "StorageBlobCreatedEventData": {
+            "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Storage.BlobCreated event.",
+            "type": "object",
+            "properties": {
+                "contentLength": {
+                    "description": "The size of the blob in bytes. This is the same as what would be returned in the Content-Length header from the blob.",
+                    "type": "integer"
+                }
+            }
+        }
+    }
+}

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/format_check_02.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/format_check_02.json
@@ -1,0 +1,22 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "2018-01-01",
+        "title": "Schema of Azure Storage events published to Azure Event Grid",
+        "description": "Describes the schema of the Azure Storage events published to Azure Event Grid. This corresponds to the Data property of an EventGridEvent."
+    },
+    "paths": {},
+    "definitions": {
+        "StorageBlobCreatedEventData": {
+            "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Storage.BlobCreated event.",
+            "type": "object",
+            "properties": {
+                "contentLength": {
+                    "description": "The size of the blob in bytes. This is the same as what would be returned in the Content-Length header from the blob.",
+                    "type": "integer",
+                    "format": "int64"
+                }
+            }
+        }
+    }
+}

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
@@ -362,7 +362,7 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(2, missing.Count());
 
             missing = messages.Where(m => m.Id == ComparisonMessages.ReadonlyPropertyChanged.Id);
-            Assert.Equal(2, missing.Count());
+            Assert.Equal(3, missing.Count());
         }
 
         /// <summary>
@@ -724,6 +724,20 @@ namespace AutoRest.Swagger.Tests
         {
             var messages = CompareSwagger("removed_property.json").ToArray();
             Assert.True(messages.Where(m => m.Id == ComparisonMessages.RemovedProperty.Id).Any());
+        }
+
+        [Fact]
+        public void FormatChanged()
+        {
+            var messages = CompareSwagger("format_check_01.json").ToArray();
+            Assert.True(messages.Where(m => m.Id == ComparisonMessages.TypeFormatChanged.Id).Any());
+        }
+
+        [Fact]
+        public void FormatRemoved()
+        {
+            var messages = CompareSwagger("format_check_02.json").ToArray();
+            Assert.True(messages.Where(m => m.Id == ComparisonMessages.TypeFormatChanged.Id).Any());
         }
     }
 }

--- a/openapi-diff/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
@@ -367,7 +367,7 @@ namespace AutoRest.Swagger.Model
                         // It's only an error if the definition is referenced in the old service.
                         context.LogBreakingChange(ComparisonMessages.RemovedDefinition, def);
                 }
-                else if (schema.IsReferenced && oldSchema.IsReferenced)
+                else
                 {
                     context.PushProperty(def);
                     schema.Compare(context, previousDefinition.Definitions[def]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/oad",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
Per the existing code, the definition will be validated only if it is referenced. It doesn't matter whether it is referenced or not. The definitions must be compared. 

This PR is related to issue: https://github.com/Azure/openapi-diff/issues/135 

@sergey-shandar Please review and approve