### PR TITLE
Adding an enum to a paramter causing Null Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.2 Release on 2019-04-19.
+
+* Fixed issue with null Enums.
+
+## 0.5.0 Release on 2019-04-12.
+
+* Update to TS 3.4 and 'types'.
+
 ## 0.4.3 Release on 2019-04-04.
 
 * Fixed issue with `AddedPath`.

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/new/enum_values_changed.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/new/enum_values_changed.json
@@ -41,6 +41,11 @@
           "type": "string",
           "description": "Enum.",
           "enum": [ "b1", "b2", "b3" ]
+        },
+        "c": {
+          "type": "string",
+          "description": "Enum.",
+          "enum": [ "c1"]
         }
       }
     }

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/enum_values_changed.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/enum_values_changed.json
@@ -41,6 +41,10 @@
           "type": "string",
           "description": "Enum.",
           "enum": [ "b1" ]
+        },
+        "c": {
+          "type": "string",
+          "description": "Enum."
         }
       }
     }

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
@@ -602,6 +602,22 @@ namespace AutoRest.Swagger.Tests
         }
 
         /// <summary>
+        /// Verifies that making constraints stricter in requests are flagged, weaker are flagged and adding enum to parameters are flagged
+        /// </summary>
+        [Fact]
+        public void RequestTypeContraintsWithNewEnum()
+        {
+            var messages = CompareSwagger("enum_values_changed.json").Where(m => m.NewJsonRef.Contains("Parameters")).ToArray();
+            var stricter = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsStronger.Id).ToArray();
+            var weaker = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsWeaker.Id).ToArray();
+            var removedValue = messages.Where(m => m.Id == ComparisonMessages.RemovedEnumValue.Id).ToArray();
+
+            Assert.Single(stricter);
+            Assert.Single(weaker);
+            Assert.Single(removedValue);
+        }
+
+        /// <summary>
         /// Verifies that changing the collection format for an array parameter is flagged.
         /// Direction: responses
         /// </summary>

--- a/openapi-diff/src/modeler/AutoRest.Swagger/Model/SwaggerObject.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/Model/SwaggerObject.cs
@@ -172,30 +172,31 @@ namespace AutoRest.Swagger.Model
 
                 // 2. Look for added elements (relaxing).
                 relaxes = this.Enum.Any(str => !prior.Enum.Contains(str));
-            }
 
-            if (context.Direction == DataDirection.Request)
-            {
-                if (constrains)
+
+                if (context.Direction == DataDirection.Request)
                 {
-                    IEnumerable<string> removedEnums = prior.Enum.Except(this.Enum);
-                    if (removedEnums.Any())
+                    if (constrains)
                     {
-                        context.LogBreakingChange(ComparisonMessages.RemovedEnumValue, String.Join(", ", removedEnums.ToList()));
+                        IEnumerable<string> removedEnums = prior.Enum.Except(this.Enum);
+                        if (removedEnums.Any())
+                        {
+                            context.LogBreakingChange(ComparisonMessages.RemovedEnumValue, String.Join(", ", removedEnums.ToList()));
+                        }
+                        return;
                     }
-                    return;
                 }
-            }
-            else if (context.Direction == DataDirection.Response)
-            {
-                if (relaxes)
+                else if (context.Direction == DataDirection.Response)
                 {
-                    IEnumerable<string> addedEnums = this.Enum.Except(prior.Enum);
-                    if (addedEnums.Any())
+                    if (relaxes)
                     {
-                        context.LogBreakingChange(ComparisonMessages.AddedEnumValue, String.Join(", ", addedEnums.ToList()));
+                        IEnumerable<string> addedEnums = this.Enum.Except(prior.Enum);
+                        if (addedEnums.Any())
+                        {
+                            context.LogBreakingChange(ComparisonMessages.AddedEnumValue, String.Join(", ", addedEnums.ToList()));
+                        }
+                        return;
                     }
-                    return;
                 }
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/oad",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
Case where https://github.com/Azure/azure-rest-api-specs/tree/master/specification/automation/resource-manager/readme.md is called for 
source tag:  package-2015-10
target tag: pacakge-2017-05-preview

It was throwing ArgumentNullException. 

With this fix, it reports proper message, indicating, there's a stricter constraint on the parameter.