### PR TITLE
Allow type addition to properties without breaking

### DIFF
--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/new/type_added.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/new/type_added.json
@@ -1,0 +1,48 @@
+﻿{
+  "swagger": 2.0,
+  "info": {
+    "title": "type_changed",
+    "version": "1.0"
+  },
+  "host": "localhost:8000",
+  "schemes": [ "http", "https" ],
+  "consumes": [ "text/plain", "text/json" ],
+  "produces": [ "text/plain" ],
+  "paths": {
+    "/api/Parameters": {
+      "put": {
+        "tag": [ "Parameters" ],
+        "operationId": "Parameters_Put",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "name": "database",
+            "in": "body",
+            "required": true,
+            "type": "object",
+            "schema": { "$ref": "#/definitions/Database" }
+          }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "Database": {
+      "properties": {
+        "a": {
+          "type": "integer",
+          "readOnly": true,
+          "description": "This is a system generated property.\nThe _rid value is empty for this operation."
+        },
+        "b": {
+          "type": "integer",
+          "readOnly": true,
+          "default": 0,
+          "description": "This property shows the number of databases returned."
+        }
+      }
+    }
+  }
+}

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/type_added.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/type_added.json
@@ -1,0 +1,47 @@
+﻿{
+  "swagger": 2.0,
+  "info": {
+    "title": "type_changed",
+    "version": "1.0"
+  },
+  "host": "localhost:8000",
+  "schemes": [ "http", "https" ],
+  "consumes": [ "text/plain", "text/json" ],
+  "produces": [ "text/plain" ],
+  "paths": {
+    "/api/Parameters": {
+      "put": {
+        "tag": [ "Parameters" ],
+        "operationId": "Parameters_Put",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "name": "database",
+            "in": "body",
+            "required": true,
+            "type": "object",
+            "schema": { "$ref": "#/definitions/Database" }
+          }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "Database": {
+      "properties": {
+        "a": {
+          "readOnly": true,
+          "description": "This is a system generated property.\nThe _rid value is empty for this operation."
+        },
+        "b": {
+          "type": "integer",
+          "readOnly": true,
+          "default": 0,
+          "description": "This property shows the number of databases returned."
+        }
+      }
+    }
+  }
+}

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
@@ -151,6 +151,17 @@ namespace AutoRest.Swagger.Tests
         }
 
         /// <summary>
+        /// Verifies that if you add the type to a schema property, it's allowed through.
+        /// </summary>
+        [Fact]
+        public void PropertyTypeAdded()
+        {
+            var messages = CompareSwagger("type_added.json").ToArray();
+            var missing = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id);
+            Assert.Empty(missing);
+        }
+
+        /// <summary>
         /// Verifies that if you change the type format of a schema property, it's caught.
         /// </summary>
         [Fact]

--- a/openapi-diff/src/modeler/AutoRest.Swagger/Model/SwaggerObject.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/Model/SwaggerObject.cs
@@ -122,9 +122,9 @@ namespace AutoRest.Swagger.Model
                 }
             }
 
-            // Are the types the same?
+            // If the type field was removed or the types don't match
 
-            if (prior.Type.HasValue != Type.HasValue || (Type.HasValue && prior.Type.Value != Type.Value))
+            if ((prior.Type.HasValue && !Type.HasValue) || (Type.HasValue && prior.Type.HasValue && prior.Type.Value != Type.Value))
             {
                 context.LogBreakingChange(ComparisonMessages.TypeChanged, 
                     Type.HasValue ? Type.Value.ToString().ToLower() : "",


### PR DESCRIPTION
In case the breaking change of adding a type where it was previously missing isn't a breaking change.
#167