### PR TITLE
Support missing operationIds in the new contracts

### DIFF
--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/new/missing_operation_id.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/new/missing_operation_id.json
@@ -1,0 +1,41 @@
+{
+  "swagger": 2.0,
+  "info": {
+    "title": "changed_operation_id",
+    "version": "1.0"
+  },
+  "host": "localhost:8000",
+  "schemes": [ "http", "https" ],
+  "paths": {
+    "/api/Paths": {
+      "get": {
+        "tag": [ "Paths" ],
+        "operationId": "Paths_Get",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/Operations": {
+      "get": {
+        "tag": [ "Operations" ],
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tag": [ "Operations" ],
+        "operationId": "Operations_Post",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [],
+        "responses": {}
+      }
+    }
+  }
+}

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/new/removed_operation_id.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/new/removed_operation_id.json
@@ -1,0 +1,41 @@
+{
+  "swagger": 2.0,
+  "info": {
+    "title": "changed_operation_id",
+    "version": "1.0"
+  },
+  "host": "localhost:8000",
+  "schemes": [ "http", "https" ],
+  "paths": {
+    "/api/Paths": {
+      "get": {
+        "tag": [ "Paths" ],
+        "operationId": "Paths_Get",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/Operations": {
+      "get": {
+        "tag": [ "Operations" ],
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tag": [ "Operations" ],
+        "operationId": "Operations_Post",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [],
+        "responses": {}
+      }
+    }
+  }
+}

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/missing_operation_id.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/missing_operation_id.json
@@ -1,0 +1,41 @@
+{
+  "swagger": 2.0,
+  "info": {
+    "title": "changed_operation_id",
+    "version": "1.0"
+  },
+  "host": "localhost:8000",
+  "schemes": [ "http", "https" ],
+  "paths": {
+    "/api/Paths": {
+      "get": {
+        "tag": [ "Paths" ],
+        "operationId": "Paths_Get",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/Operations": {
+      "get": {
+        "tag": [ "Operations" ],
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tag": [ "Operations" ],
+        "operationId": "Operations_Post",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [],
+        "responses": {}
+      }
+    }
+  }
+}

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/removed_operation_id.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/removed_operation_id.json
@@ -1,0 +1,42 @@
+{
+  "swagger": 2.0,
+  "info": {
+    "title": "changed_operation_id",
+    "version": "1.0"
+  },
+  "host": "localhost:8000",
+  "schemes": [ "http", "https" ],
+  "paths": {
+    "/api/Paths": {
+      "get": {
+        "tag": [ "Paths" ],
+        "operationId": "Paths_Get",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/api/Operations": {
+      "get": {
+        "tag": [ "Operations" ],
+        "operationId": "Operations_Get",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [],
+        "responses": {}
+      },
+      "post": {
+        "tag": [ "Operations" ],
+        "operationId": "Operations_Post",
+        "produces": [
+          "text/plain"
+        ],
+        "parameters": [],
+        "responses": {}
+      }
+    }
+  }
+}

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
@@ -54,7 +54,7 @@ namespace AutoRest.Swagger.Tests
             Assert.True(oldLocation != null || newLocation != null);
             switch (message.Mode)
             {
-                case MessageType.Update:                    
+                case MessageType.Update:
                     break;
                 case MessageType.Addition:
                     Assert.NotNull(newLocation);
@@ -230,6 +230,32 @@ namespace AutoRest.Swagger.Tests
         }
 
         /// <summary>
+        /// Verifies that if the operations id is missing for a path in both old and new contracts,
+        /// the execution doesn't fail and no version change is required.
+        /// </summary>
+        [Fact]
+        public void OperationIdIsNull()
+        {
+            var messages = CompareSwagger("missing_operation_id.json").ToArray();
+            Assert.Single(messages);
+            Assert.Equal(ComparisonMessages.NoVersionChange.Id, messages[0].Id);
+        }
+
+        /// <summary>
+        /// Verifies that if you remove an operationId from an operation in a path, it's caught.
+        /// </summary>
+        [Fact]
+        public void OperationIdRemoved()
+        {
+            var messages = CompareSwagger("removed_operation_id.json").ToArray();
+            var missing = messages.Where(m => m.Id == ComparisonMessages.ModifiedOperationId.Id);
+            Assert.Equal(1, missing.Count());
+            var x = missing.First(m => m.Severity == Category.Error && m.NewJsonRef == "new/removed_operation_id.json#/paths/~1api~1Operations/get");
+            Assert.NotNull(x.NewJson());
+            Assert.NotNull(x.OldJson());
+        }
+
+        /// <summary>
         /// Verifies that if you added new paths / operations, it's caught.
         /// </summary>
         [Fact]
@@ -328,7 +354,7 @@ namespace AutoRest.Swagger.Tests
             var missing = messages.Where(m => m.Id == ComparisonMessages.AddedReadOnlyPropertyInResponse.Id);
             Assert.Single(missing);
             Assert.NotEmpty(missing.Where(
-                m => m.Severity == Category.Info && 
+                m => m.Severity == Category.Info &&
                 m.NewJsonRef == "new/readonly_changes.json#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1checkNameAvailability/post/responses/200/schema/properties"));
         }
 
@@ -342,7 +368,7 @@ namespace AutoRest.Swagger.Tests
             var missing = messages.Where(m => m.Id == ComparisonMessages.AddedPropertyInResponse.Id);
             Assert.Single(missing);
             var x = missing.First(
-                m => m.Severity == Category.Error && 
+                m => m.Severity == Category.Error &&
                 m.NewJsonRef.Contains(
                     "#/paths/~1subscriptions~1{subscriptionId}~1providers~1Microsoft.Storage~1checkNameAvailability/post/responses/200/schema/properties"
                 )
@@ -776,7 +802,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void CommonParameterOverride()
         {
-            // For the parameters both defined in path/operation, the operation parameters should override path parameters. 
+            // For the parameters both defined in path/operation, the operation parameters should override path parameters.
             var messages = CompareSwagger("common_parameter_check_03.json").ToArray();
             Assert.Empty(messages.Where(m => m.Severity == Category.Error));
         }

--- a/openapi-diff/src/modeler/AutoRest.Swagger/Model/Operation.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/Model/Operation.cs
@@ -98,7 +98,7 @@ namespace AutoRest.Swagger.Model
 
             base.Compare(context, previous);
 
-            if (!OperationId.Equals(priorOperation.OperationId))
+            if (OperationId != priorOperation.OperationId)
             {
                 context.LogBreakingChange(ComparisonMessages.ModifiedOperationId, priorOperation.OperationId, OperationId);
             }
@@ -158,15 +158,15 @@ namespace AutoRest.Swagger.Model
             context.PushProperty("parameters");
 
             var priorOperationParameters = priorOperation.Parameters.Select(param =>
-                string.IsNullOrWhiteSpace(param.Reference) ? param : 
+                string.IsNullOrWhiteSpace(param.Reference) ? param :
                 FindReferencedParameter(param.Reference, previousRoot.Parameters)
             );
             foreach (var oldParam in priorOperationParameters)
             {
                 SwaggerParameter newParam = FindParameter(oldParam.Name, Parameters, currentRoot.Parameters);
 
-                // we should use PushItemByName instead of PushProperty because Swagger `parameters` is 
-                // an array of paremters.  
+                // we should use PushItemByName instead of PushProperty because Swagger `parameters` is
+                // an array of paremters.
                 context.PushItemByName(oldParam.Name);
 
                 if (newParam != null)
@@ -195,7 +195,7 @@ namespace AutoRest.Swagger.Model
 
                 if (oldParam == null)
                 {
-                    // Did not find required parameter in the old swagger i.e required parameter is added                    
+                    // Did not find required parameter in the old swagger i.e required parameter is added
                     context.PushItemByName(newParam.Name);
                     context.LogBreakingChange(ComparisonMessages.AddingRequiredParameter, newParam.Name);
                     context.Pop();


### PR DESCRIPTION
* If the operationId is missing in both the old and the new contracts, no version change is required
* If the operationId is removed in the new contract, it's caught as a breaking change