### PR TITLE
Bugfix for circular allOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.8.12 Released on 2021-06-25
+
+- bug fix for checking circular allOf.
 ## 0.8.11 Released on 2021-05-31
 
 - ConstraintIsWeaker & ConstraintIsStronger do not check adding/removing enum values.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/oad",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/oad",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",

--- a/src/lib/util/resolveSwagger.ts
+++ b/src/lib/util/resolveSwagger.ts
@@ -236,17 +236,17 @@ export class ResolveSwagger {
     return parentProperty.type === unwrappedProperty.type && parentProperty.format === unwrappedProperty.format
   }
 
-  private checkCircularAllOf(schema: any, visited: Set<any> | undefined, referenceChain: string[]) {
-    visited = visited ? visited : new Set<any>()
+  private checkCircularAllOf(schema: any, visited: any[] | undefined, referenceChain: string[]) {
+    visited = visited ? visited : []
     referenceChain = referenceChain ? referenceChain : []
     if (schema) {
-      if (visited.has(schema)) {
+      if (visited?.includes(schema)) {
         throw new Error("Found circular allOf reference: " + referenceChain.join("-> "))
       }
       if (!schema.allOf) {
         return
       }
-      visited.add(schema)
+      visited.push(schema)
       sm.values(schema.allOf)
         .filter(s => (s as any).$ref)
         .forEach(s => {
@@ -256,6 +256,7 @@ export class ResolveSwagger {
           this.checkCircularAllOf(referredSchema, visited, referenceChain)
           referenceChain.pop()
         })
+      visited.pop()
     }
   }
 

--- a/src/lib/util/resolveSwagger.ts
+++ b/src/lib/util/resolveSwagger.ts
@@ -240,7 +240,7 @@ export class ResolveSwagger {
     visited = visited ? visited : []
     referenceChain = referenceChain ? referenceChain : []
     if (schema) {
-      if (visited?.includes(schema)) {
+      if (visited.includes(schema)) {
         throw new Error("Found circular allOf reference: " + referenceChain.join("-> "))
       }
       if (!schema.allOf) {


### PR DESCRIPTION
The old algorithm contains false positive,

https://github.com/test-repo-billy/azure-rest-api-specs/blob/master/specification/cognitiveservices/data-plane/LUIS/Authoring/stable/v2.0/LUIS-Authoring.json