### PR TITLE
Add rule and test for RemovedOptionalParameter

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@
 
 [1023 - TypeFormatChanged](rules/1023.md)
 
-[1023 - ConstraintIsStronger](rules/1024.md)
+[1024 - ConstraintIsStronger](rules/1024.md)
 
 [1025 - RequiredStatusChange](rules/1025.md)
 
@@ -89,3 +89,5 @@
 [1044 - XmsLongRunningOperationChanged](rules/1044.md)
 
 [1045 - AddedOptionalProperty](rules/1045.md)
+
+[1046 - RemovedOptionalParameter](rules/1046.md)

--- a/docs/rules/1046.md
+++ b/docs/rules/1046.md
@@ -1,0 +1,105 @@
+### 1046 - RemovedOptionalParameter
+
+**Description**: Checks whether optional parameter is removed / made required from the previous specification.
+
+**Cause**: This is considered a breaking change. This change requires new api-version.
+
+**Example**: Optional parameter `c` is being removed without revising api-version.
+
+Old specification
+```json5
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "swagger",
+    "description": "The Azure Management API.",
+    "version": "2016-12-01",
+    ...
+    ...
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Contoso/resource1/{a}": {
+      "get": {
+        ...
+        ...
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "a",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "b",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "c",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ]
+        ...
+        ...
+      },
+      "put": {
+        ...
+      }
+    }
+    ...
+    ... 
+```
+
+New specification
+```json5
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "swagger",
+    "description": "The Azure Management API.",
+    "version": "2016-12-01",
+    ...
+    ...
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Contoso/resource1/{a}": {
+      "get": {
+        ...
+        ...
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "a",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "b",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          }
+        ]
+        ...
+        ...
+      },
+      "put": {
+        ...
+      }
+    }
+    ...
+    ...     
+```

--- a/docs/rules/1046.md
+++ b/docs/rules/1046.md
@@ -2,7 +2,7 @@
 
 **Description**: Checks whether optional parameter is removed / made required from the previous specification.
 
-**Cause**: This is considered a breaking change. This change requires new api-version.
+**Cause**: This is considered a breaking change. 
 
 **Example**: Optional parameter `c` is being removed without revising api-version.
 

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/optional_parameter.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/old/optional_parameter.json
@@ -41,7 +41,7 @@
           {
             "name": "f",
             "in": "query",
-            "required": true,
+            "required": false,
             "type": "string",
             "enum": [ "theonlyvalue" ]
           }

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
@@ -301,6 +301,20 @@ namespace AutoRest.Swagger.Tests
         }
 
         /// <summary>
+        /// Verifies that if you remove a required parameter, it's found.
+        /// </summary>
+        [Fact]
+        public void OptionalParameterRemoved()
+        {
+            var messages = CompareSwagger("optional_parameter.json").ToArray();
+            var missing = messages.Where(m => m.Id == ComparisonMessages.RemovedOptionalParameter.Id);
+            Assert.Single(missing);
+            var x = missing.First(m => m.Severity == Category.Error && m.OldJsonRef == "old/optional_parameter.json#/paths/~1api~1Parameters~1{a}/get/parameters/4");
+            Assert.Null(x.NewJson());
+            Assert.NotNull(x.OldJson());
+        }
+
+        /// <summary>
         /// Verifies that if you add a required property in the model, it's found.
         /// </summary>
         [Fact]

--- a/openapi-diff/src/modeler/AutoRest.Swagger/ComparisonMessages.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/ComparisonMessages.cs
@@ -98,6 +98,14 @@
             Type = MessageType.Removal
         };
 
+        public static MessageTemplate RemovedOptionalParameter = new MessageTemplate
+        {
+            Id = 1046,
+            Code = nameof(ComparisonMessages.RemovedOptionalParameter),
+            Message = "The optional parameter '{0}' was removed in the new version.",
+            Type = MessageType.Removal
+        };
+
         public static MessageTemplate ChangedParameterOrder = new MessageTemplate
         {
             Id = 1042,

--- a/openapi-diff/src/modeler/AutoRest.Swagger/Model/Operation.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/Model/Operation.cs
@@ -229,6 +229,9 @@ namespace AutoRest.Swagger.Model
                 {
                     // Removed required parameter
                     context.LogBreakingChange(ComparisonMessages.RemovedRequiredParameter, oldParam.Name);
+                } else {
+                    // Removed optional parameter
+                    context.LogBreakingChange(ComparisonMessages.RemovedOptionalParameter, oldParam.Name);
                 }
 
                 context.Pop();


### PR DESCRIPTION
This PR adds a check for a removed optional parameter and when detected reports this as a breaking change.  Tests included.

Fixes #205 