### PR TITLE
Support xs-ms-enum values without the 'value' label

### DIFF
--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/invalid_swagger_specification.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/invalid_swagger_specification.json
@@ -1,0 +1,3 @@
+{
+  "invalid_swagger_specification"
+}

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/swagger_specification.json
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/swagger_specification.json
@@ -1,0 +1,257 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "contact": {
+      "email": "apiteam@swagger.io",
+      "name": "Swagger API Team",
+      "url": "http://swagger.io"
+    },
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the Swagger 2.0 specification",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "termsOfService": "http://swagger.io/terms/",
+    "title": "Swagger Petstore",
+    "version": "1.0.0"
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "collectionFormat": "multi",
+            "description": "tags to filter by",
+            "in": "query",
+            "items": {
+              "type": "string"
+            },
+            "name": "tags",
+            "required": false,
+            "type": "array"
+          },
+          {
+            "description": "maximum number of results to return",
+            "format": "int32",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "items": {
+                "$ref": "#/definitions/Pet"
+              },
+              "type": "array"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        },
+        "description": "Returns all pets from the system that the user has access to the system",
+        "operationId": "findPets"
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "Pet to add to the store",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NewPet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        },
+        "description": "Creates a new pet in the store. Duplicates are allowed",
+        "operationId": "addPet"
+      }
+    },
+    "/pets/{id}": {
+      "delete": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "ID of pet to delete",
+            "format": "int64",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        },
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet"
+      },
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "description": "ID of pet to fetch",
+            "format": "int64",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        },
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "find pet by id"
+      }
+    }
+  },
+  "definitions": {
+    "Error": {
+      "properties": {
+        "code": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "NewPet": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "Pet": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/NewPet"
+        },
+        {
+          "properties": {
+            "id": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "petType": {
+              "$ref": "#/definitions/PetType"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "PetType": {
+      "enum": [
+        "Mammals",
+        "Fish",
+        "Birds",
+        "Reptiles",
+        "Amphibians",
+        "Invertebrates"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "name": "PetType",
+        "modelAsString": false,
+        "values": [
+          {
+            "value": 0,
+            "description": "humans and all other animals that are warm-blooded vertebrates",
+            "name": "Mammals"
+          },
+          {
+            "value": 1,
+            "description": "aquatic, craniate, gill-bearing animals that lack limbs with digits"
+          },
+          {
+            "value": 2,
+            "name": "Birds"
+          },
+          3,
+          4,
+          5
+        ],
+        "x-nullable": false
+      }
+    }
+  },
+  "x-components": {}
+}

--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerParserTests.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerParserTests.cs
@@ -1,0 +1,48 @@
+using System.Reflection;
+
+using System.IO;
+using AutoRest.Swagger.Model;
+using Newtonsoft.Json;
+using Xunit;
+using OpenApiDiff.Core;
+
+namespace AutoRest.Swagger.UTest
+{
+    /// <summary>
+    /// This class contains tests about the swagger parser
+    /// </summary>
+    [Collection("Comparison Tests")]
+    public class SwaggerParserTest
+    {
+        private static string ReadSwaggerFile(string fileName)
+        {
+            var baseDir = Directory.GetParent(typeof(SwaggerParserTest).GetTypeInfo().Assembly.Location)
+                .ToString();
+            var filePath = Path.Combine(baseDir, "Resource", "Swagger", fileName);
+            return File.ReadAllText(filePath);
+        }
+
+        /// <summary>
+        /// Verifies that the Parser throws an Exception when an in valid json is given
+        /// </summary>
+        [Fact]
+        public void SwaggerParser_Should_Throw_Exception_When_Invalid_Json()
+        {
+            const string fileName = "invalid_swagger_specification.json";
+            var documentAsString = ReadSwaggerFile(fileName);
+            Assert.Throws<JsonReaderException>(() => SwaggerParser.Parse(documentAsString, fileName));
+        }
+
+        /// <summary>
+        /// Verifies that a valid JsonDocument object is parsed when input is a valid Swagger
+        /// </summary>
+        [Fact]
+        public void SwaggerParser_Should_Return_Valid_Swagger_Document_Object()
+        {
+            const string fileName = "swagger_specification.json";
+            var documentAsString = ReadSwaggerFile(fileName);
+            var validSwaggerDocument = SwaggerParser.Parse(documentAsString, fileName);
+            Assert.IsType<JsonDocument<ServiceDefinition>>(validSwaggerDocument);
+        }
+    }
+}

--- a/openapi-diff/src/modeler/AutoRest.Swagger/Model/XmsEnumExtension.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/Model/XmsEnumExtension.cs
@@ -7,22 +7,30 @@ using System.Collections.Generic;
 namespace AutoRest.Swagger.Model
 {
     /// <summary>
-    /// The object provides metadata about the API. 
-    /// The metadata can be used by the clients if needed, and can be presented 
+    /// The object provides metadata about the API.
+    /// The metadata can be used by the clients if needed, and can be presented
     /// in the Swagger-UI for convenience.
     /// </summary>
-    
+
     public class XmsEnumValue
     {
         public dynamic value;
         public string description;
         public string name;
+        public XmsEnumValue(dynamic v)
+        {
+            value = v;
+        }
+
+        public static explicit operator XmsEnumValue(int v) => new XmsEnumValue(v);
+        public static explicit operator XmsEnumValue(long v) => new XmsEnumValue(v);
+        public static explicit operator XmsEnumValue(string v) => new XmsEnumValue(v);
     }
 
-    public class XmsEnumExtension 
+    public class XmsEnumExtension
     {
         public string Name { get; set; }
-        
+
         public Boolean ModelAsString { get; set; }
 
         public IList<XmsEnumValue> values { get; set; }


### PR DESCRIPTION
This commit fixes the following issue https://github.com/Azure/openapi-diff/issues/216