### PR TITLE
Match files named "*test" or "*Test"

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
       "dist/**/*.js"
     ],
     "testMatch": [
-      "**/*test.js"
+      "**/*[tT]est.js"
     ]
   },
   "scripts": {


### PR DESCRIPTION
- Required to run all tests on Linux