### PR TITLE
Replace "npm install" with "npm ci"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ To execute any instructions in this file, first ensure you fulfill all the follo
 1. Install [.NET runtime and SDK](https://aka.ms/dotnet-download), version 6 or higher.
 1. Install [.NET CLI tools](https://github.com/dotnet/cli/releases) version 2.0.0 or higher.
 1. Execute all commands in this file from your [`openapi-diff`] git repo local clone root dir.
-1. Run `npm install` to install the required node modules.
+1. Run `npm ci` to install the required node modules.
 
 ## Build the code
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,8 @@ pool:
   vmImage: windows-2022
 
 steps:
-- script: npm install
-  displayName: npm install
+- script: npm ci
+  displayName: npm ci
 - script: npm test
   displayName: test
 - script: npm pack

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "tsc": "tsc",
     "ts.test": "tsc && jest",
     "test": "npm run dn.test && npm run ts.test",
-    "prepack": "npm install && npm run dn.publish && tsc",
+    "prepack": "npm ci && npm run dn.publish && tsc",
     "tslint": "tslint --project tsconfig.json ./src/**/*.ts ",
     "tslint-fix": "tslint --fix --project tsconfig.json ./src/**/*.ts",
     "tslint-check": "tslint-config-prettier-check ./tslint.json"


### PR DESCRIPTION
- Ensures clean install of dependencies matching lockfile