### PR TITLE
Improve message for different format value

### DIFF
--- a/openapi-diff/src/modeler/AutoRest.Swagger/ComparisonMessages.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/ComparisonMessages.cs
@@ -310,7 +310,7 @@
         {
             Id = 1023,
             Code = nameof(ComparisonMessages.TypeFormatChanged),
-            Message = "The new version has a different format than the previous one.",
+            Message = "The new version has a different format '{0}' than the previous one '{1}'.",
             Type = MessageType.Update
         };
 

--- a/openapi-diff/src/modeler/AutoRest.Swagger/Model/SwaggerObject.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/Model/SwaggerObject.cs
@@ -42,7 +42,7 @@ namespace AutoRest.Swagger.Model
         /// Describes the type of additional properties in the data type.
         /// </summary>
         public virtual Schema AdditionalProperties { get; set; }
-        
+
         public virtual string Description { get; set; }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace AutoRest.Swagger.Model
 
             if ((Type.HasValue && prior.Type.HasValue && prior.Type.Value != Type.Value))
             {
-                context.LogError(ComparisonMessages.TypeChanged, 
+                context.LogError(ComparisonMessages.TypeChanged,
                     Type.HasValue ? Type.Value.ToString().ToLower() : "",
                     prior.Type.HasValue ? prior.Type.Value.ToString().ToLower() : "");
             }
@@ -206,7 +206,7 @@ namespace AutoRest.Swagger.Model
                         context.LogBreakingChange(ComparisonMessages.RemovedEnumValue, String.Join(", ", removedEnums.ToList()));
                     }
                 }
-            
+
                 if (relaxes)
                 {
                     IEnumerable<string> addedEnums = this.Enum.Except(prior.Enum);
@@ -282,11 +282,11 @@ namespace AutoRest.Swagger.Model
                 throw new ArgumentNullException("context");
             }
 
-            if (prior.Format == null && Format != null || 
+            if (prior.Format == null && Format != null ||
                 prior.Format != null && Format == null ||
                 prior.Format != null && Format != null && !prior.Format.Equals(Format) && !isFormatChangeAllowed(context,prior))
-            {   
-                context.LogBreakingChange(ComparisonMessages.TypeFormatChanged);
+            {
+                context.LogBreakingChange(ComparisonMessages.TypeFormatChanged, Format, prior);
             }
         }
 
@@ -414,8 +414,8 @@ namespace AutoRest.Swagger.Model
         {
             int p = 0;
             int c = 0;
-            return int.TryParse(previous, out p) && 
-                   int.TryParse(current, out c) && 
+            return int.TryParse(previous, out p) &&
+                   int.TryParse(current, out c) &&
                    (isLowerBound ? (c > p) : (c < p));
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/oad",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",

--- a/src/test/expandsAllOfFullCoversTest.ts
+++ b/src/test/expandsAllOfFullCoversTest.ts
@@ -87,7 +87,7 @@ test("expands allOf full covers", async () => {
     {
       id: "1023",
       code: "TypeFormatChanged",
-      message: "The new version has a different format than the previous one.",
+      message: "The new version has a different format '' than the previous one 'AutoRest.Swagger.Model.Schema'.",
       old: {
         ref: `${oldFilePath}#/definitions/DataBaseProperties/properties/b`,
         path: "definitions.Database.properties.b",


### PR DESCRIPTION
This PR makes a very small change to the message text for the TypeFormatChanged message. It adds the old and new format value to the message. This will make it easier to determine when the change is benign, as most of these are, since this information is often sufficient and putting it in the message text will avoid the need to navigate into both files to extract this information.