### PR TITLE
Add test for "No enum match for final-state-via:operation-location"

### DIFF
--- a/src/test/operation-location/operation-location.json
+++ b/src/test/operation-location/operation-location.json
@@ -1,0 +1,10 @@
+{
+    "swagger": "2.0",
+    "info": {
+      "title": "operation-location",
+      "version": "1.0"
+    },
+    "paths": {
+    }
+  }
+  

--- a/src/test/operation-location/operation-location.json
+++ b/src/test/operation-location/operation-location.json
@@ -1,10 +1,42 @@
 {
-    "swagger": "2.0",
-    "info": {
-      "title": "operation-location",
-      "version": "1.0"
-    },
-    "paths": {
+  "swagger": "2.0",
+  "info": {
+    "title": "operation-location",
+    "version": "1.0"
+  },
+  "paths": {
+    "/foo": {
+      "post": {
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/Consent"
+            },
+            "headers": {
+              "Operation-Id": {
+                "type": "string",
+                "description": "ID of the operation."
+              },
+              "Operation-Location": {
+                "description": "The location of the operation job. Use this URL to monitor operation status.",
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          },
+          "default": {
+            "description": "An error occurred.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "operation-location"
+        }
+      }
     }
   }
-  
+}

--- a/src/test/operationLocationTest.ts
+++ b/src/test/operationLocationTest.ts
@@ -3,7 +3,8 @@ import * as path from "path"
 import { OpenApiDiff } from "../index"
 import { fileUrl } from "./fileUrl"
 
-test("operation-location", async () => {
+// Regression test for bug #310
+test("diffing a spec with operation-location bug with itself does not throw", async () => {
   const diff = new OpenApiDiff({})
   const file = "src/test/operation-location/operation-location.json"
   const resultStr = await diff.compare(file, file)

--- a/src/test/operationLocationTest.ts
+++ b/src/test/operationLocationTest.ts
@@ -1,0 +1,33 @@
+import * as assert from "assert"
+import * as path from "path"
+import * as index from "../index"
+import { fileUrl } from "./fileUrl"
+
+test("operation-location", async () => {
+  const diff = new index.OpenApiDiff({})
+  const file = "src/test/operation-location/operation-location.json"
+  const resultStr = await diff.compare(file, file)
+  const result = JSON.parse(resultStr)
+  const filePath = fileUrl(path.resolve(file))
+  const expected = [
+    {
+      code: "NoVersionChange",
+      docUrl: "https://github.com/Azure/openapi-diff/tree/master/docs/rules/1001.md",
+      id: "1001",
+      message: "The versions have not changed.",
+      mode: "Update",
+      new: {
+        ref: `${filePath}#`,
+        path: "",
+        location: `${filePath}:1:1`
+      },
+      old: {
+        ref: `${filePath}#`,
+        path: "",
+        location: `${filePath}:1:1`
+      },
+      type: "Info"
+    }
+  ]
+  assert.deepStrictEqual(result, expected)
+})

--- a/src/test/operationLocationTest.ts
+++ b/src/test/operationLocationTest.ts
@@ -1,10 +1,10 @@
 import * as assert from "assert"
 import * as path from "path"
-import * as index from "../index"
+import { OpenApiDiff } from "../index"
 import { fileUrl } from "./fileUrl"
 
 test("operation-location", async () => {
-  const diff = new index.OpenApiDiff({})
+  const diff = new OpenApiDiff({})
   const file = "src/test/operation-location/operation-location.json"
   const resultStr = await diff.compare(file, file)
   const result = JSON.parse(resultStr)


### PR DESCRIPTION
- Fixes #310
- Depends on https://github.com/Azure/autorest/pull/4928
- Covers 62 of 94 crashes in specs/main
