### PR TITLE
Display path in `TypeFormatChanged` message

### DIFF
--- a/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
@@ -129,10 +129,9 @@ namespace AutoRest.Swagger.Tests
             var messages = CompareSwagger("removed_definition.json").ToArray();
             var missing = messages.Where(m => m.Id == ComparisonMessages.RemovedDefinition.Id);
             Assert.NotEmpty(missing);
-            var missing0 = missing.First();
-            Assert.Equal(Category.Error, missing0.Severity);
-            Assert.NotNull(missing0.NewJson());
-            Assert.NotNull(missing0.OldJson());
+            ComparisonMessage firstMessage = missing.First();
+            Assert.Equal(Category.Error, firstMessage.Severity);
+            Assert.NotNull(firstMessage.NewJson());
         }
 
         /// <summary>
@@ -183,13 +182,16 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void PropertyTypeFormatChanged()
         {
-            var messages = CompareSwagger("misc_checks_01.json").ToArray();
-            var missing = messages.Where(m => m.Id == ComparisonMessages.TypeFormatChanged.Id);
+            ComparisonMessage[] messages = CompareSwagger("misc_checks_01.json").ToArray();
+            List<ComparisonMessage> missing =
+                messages.Where(m => m.Id == ComparisonMessages.TypeFormatChanged.Id).ToList();
             Assert.NotEmpty(missing);
-            var error = missing.Where(err => err.NewJsonRef.StartsWith("new/misc_checks_01.json#/definitions/")).FirstOrDefault();
+            ComparisonMessage error = missing.FirstOrDefault(err => err.NewJsonRef.StartsWith("new/misc_checks_01.json#/definitions/"));
             Assert.NotNull(error);
             Assert.Equal(Category.Error, error.Severity);
             Assert.Equal("new/misc_checks_01.json#/definitions/Database/properties/c", error.NewJsonRef);
+            Assert.Contains(error.OldJsonRef, error.Message);
+            Assert.Contains(error.NewJsonRef, error.Message);
         }
 
         /// <summary>

--- a/openapi-diff/src/modeler/AutoRest.Swagger/ComparisonContext.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/ComparisonContext.cs
@@ -101,6 +101,10 @@ namespace AutoRest.Swagger
             }
         }
 
+        public string PathJsonPointerInPreviousDoc => Path.JsonPointer(_PreviousRootDoc);
+
+        public string PathJsonPointerInCurrentDoc => Path.JsonPointer(_CurrentRootDoc);
+
         private IList<ComparisonMessage> _messages = new List<ComparisonMessage>();
     }
 

--- a/openapi-diff/src/modeler/AutoRest.Swagger/ComparisonMessage.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/ComparisonMessage.cs
@@ -114,6 +114,10 @@ namespace AutoRest.Swagger
 
         public string NewLocation() => Location(NewDoc, NewJson());
 
+        /// <summary>
+        /// The output of this method call is parsed into OadMessage type in openapi-alps,
+        /// by openapi-alps breaking-change.ts / runOad function.
+        /// </summary>
         public string GetValidationMessagesAsJson()
         {
             var rawMessage = new JsonComparisonMessage

--- a/openapi-diff/src/modeler/AutoRest.Swagger/ComparisonMessages.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/ComparisonMessages.cs
@@ -310,7 +310,7 @@
         {
             Id = 1023,
             Code = nameof(ComparisonMessages.TypeFormatChanged),
-            Message = "The new version has a different format '{0}' than the previous one '{1}'.",
+            Message = "The new version has a different format '{0}' than the previous one '{1}'. Path (new): '{2}'.",
             Type = MessageType.Update
         };
 

--- a/openapi-diff/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
@@ -108,7 +108,7 @@ namespace AutoRest.Swagger.Model
         /// Compare a modified document node (this) to a previous one and look for breaking as well as non-breaking changes.
         /// </summary>
         /// <param name="context">The modified document context.</param>
-        /// <param name="previous">The original document model.</param>
+        /// <param name="previousDefinition">The original document model.</param>
         /// <returns>A list of messages from the comparison.</returns>
         public override IEnumerable<ComparisonMessage> Compare(
             ComparisonContext<ServiceDefinition> context,
@@ -196,7 +196,7 @@ namespace AutoRest.Swagger.Model
 
                 if (!newPaths.TryGetValue(p, out var operations))
                 {
-                    // Entrie path was removeed
+                    // Entire path was removed
                     context.LogBreakingChange(ComparisonMessages.RemovedPath, path);
                 }
                 else
@@ -242,7 +242,7 @@ namespace AutoRest.Swagger.Model
                 context.Pop();
             }
 
-            // Check wether any new paths are being added
+            // Check whether any new paths are being added
             foreach (var path in newPaths.Keys)
             {
                 context.PushPathProperty(path);

--- a/openapi-diff/src/modeler/AutoRest.Swagger/Model/SwaggerObject.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/Model/SwaggerObject.cs
@@ -285,9 +285,14 @@ namespace AutoRest.Swagger.Model
 
             if (prior.Format == null && Format != null ||
                 prior.Format != null && Format == null ||
-                prior.Format != null && Format != null && !prior.Format.Equals(Format) && !isFormatChangeAllowed(context,prior))
+                prior.Format != null && Format != null && !prior.Format.Equals(Format) && !isFormatChangeAllowed(context, prior))
             {
-                context.LogBreakingChange(ComparisonMessages.TypeFormatChanged, Format, prior.Format);
+                context.LogBreakingChange(
+                    ComparisonMessages.TypeFormatChanged,
+                    Format,
+                    prior.Format,
+                    context.PathJsonPointerInCurrentDoc                    
+                    );
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/oad",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",

--- a/src/test/expandsAllOfFullCoversTest.ts
+++ b/src/test/expandsAllOfFullCoversTest.ts
@@ -87,7 +87,8 @@ test("expands allOf full covers", async () => {
     {
       id: "1023",
       code: "TypeFormatChanged",
-      message: "The new version has a different format '' than the previous one 'int32'.",
+      message:
+        "The new version has a different format '' than the previous one 'int32'. Path (new): 'new/misc_checks_01.json#/definitions/Database/properties/c'.",
       old: {
         ref: `${oldFilePath}#/definitions/DataBaseProperties/properties/b`,
         path: "definitions.Database.properties.b",


### PR DESCRIPTION
Addresses:
- https://github.com/Azure/azure-sdk-tools/issues/7182

Example of error message after changes (new text **emboldened**):

> The new version has a different format 'int64' than the previous one 'int32'. **Previous path: 'old/misc_checks_01.json#/definitions/Database/properties/c'. Current path: 'new/misc_checks_01.json#/definitions/Database/properties/c'**.

@mikekistler should I make it so that **all** errors messages **always** show previous/current paths?

I noticed we already display stuff like [this](https://github.com/Azure/azure-rest-api-specs/pull/25569/checks):

![image](https://github.com/Azure/openapi-diff/assets/4429827/39650d4c-f4fe-4796-84e5-abd86039f333)

was the `Old / New` not enough?

Implementation note:

The `Old / New` is populated by [`azureSwaggerValidation/src/unifiedPipelineHelper.ts/oadMessagesToResultMessageRecords`](
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/openapi-alps?path=private/azure-swagger-validation/azureSwaggerValidation/src/unifiedPipelineHelper.ts&version=GCbbcbd2858f263488213916c524911844c21cc1ee&line=114&lineStartColumn=3&lineEndColumn=36&_a=contents):

``` typescript
  oadMessagesToResultMessageRecords(
    messages: OadMessage[],
    baseBranchName: string | null = null
  ): ResultMessageRecord[] {
    return messages.map((oadMessage) => {
      const paths: JsonPath[] = [];
      if (oadMessage.new.location) {
        paths.push({
          tag: "New",
          path: sourceBranchHref(this.context, oadMessage.new.location || ""),
        });
      }
      if (oadMessage.old.location) {
        paths.push({
          tag: "Old",
          path: specificBranchHref(
            this.context,
            oadMessage.old.location || "",
            baseBranchName || defaultBaseBranch
          ),
        });
      }
```

where `messages: OadMessage[]` come from:

[`breaking-change.ts / doBreakingChangeDetection`](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/openapi-alps?path=private/azure-swagger-validation/azureSwaggerValidation/src/breaking-change.ts&version=GC0ba4a42ea83894a1aed452a923ab80914c1fccf9&line=565&lineEnd=569&lineStartColumn=1&lineEndColumn=26&_a=contents):

``` typescript
      const filteredOadMessages = (
        option.isCrossVersion
          ? ruleManager.handleCrossApiVersion(oadMessages, ctx)
          : ruleManager.handleSameApiVersion(oadMessages, ctx)
      ).map(postHandler);
```

where `filteredOadMessages` are derived from [`breaking-change.ts / runOad`](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/openapi-alps?path=private/azure-swagger-validation/azureSwaggerValidation/src/breaking-change.ts&version=GC0ba4a42ea83894a1aed452a923ab80914c1fccf9&line=176&lineEnd=190&lineStartColumn=1&lineEndColumn=22&_a=contents)

``` typescript
oadCompareOutput = await oad.compare/* variations */
// Fix up output from OAD as it does not output valid JSON.
// Specifically, replace e.g. "}  {", with "},{".
oadCompareOutput = oadCompareOutput.replace(/}\s+{/gi, "},{");

let oadMessages = JSON.parse(oadCompareOutput) as OadMessage[];
