### PR TITLE
Fix bug where `eslint` crashed `openapi-alps` due to being in `module` format instead of CommonJS. Bump to `@azure/oad`: `0.10.12`.

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,7 @@
 // by openapi-alps:
 // https://github.com/Azure/openapi-diff/pull/335/files#r1649413983
 
-const eslint = require("@eslint/js");
+const eslint = require("@eslint/js")
 const tseslint = require("typescript-eslint")
 
 module.exports = tseslint.config(

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,8 +33,7 @@ module.exports = tseslint.config(
     rules: {
       // Rules disabled as part of migration from tslint
       // https://github.com/Azure/openapi-diff/pull/335
-      // kja turned off to check if it works in CI
-      // "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-unnecessary-type-assertion": "off",
       "@typescript-eslint/no-unsafe-argument": "off",
       "@typescript-eslint/no-unsafe-assignment": "off",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,36 +4,37 @@
 // https://typescript-eslint.io/getting-started#step-2-configuration
 // https://typescript-eslint.io/getting-started/typed-linting
 
-import eslint from "@eslint/js"
-import { dirname } from "path"
-import tseslint from "typescript-eslint"
-import { fileURLToPath } from "url"
+// This file must be in CommonJS format ('require()') instead of ESModules ('import') due to how it is consumed
+// by openapi-alps:
+// https://github.com/Azure/openapi-diff/pull/335/files#r1649413983
 
-// Needed to support Node < 20.11 per:
-// https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules
-// as linked from: https://typescript-eslint.io/getting-started/typed-linting
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const eslint = require("@eslint/js");
+const tseslint = require("typescript-eslint")
 
-export default tseslint.config(
+module.exports = tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
   {
     languageOptions: {
       parserOptions: {
         project: true,
+        // Note: __dirname is coming CommonJS:
+        // https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules
+        // as linked from: https://typescript-eslint.io/getting-started/typed-linting
         tsconfigRootDir: __dirname
       }
     }
   },
   {
     // Based on https://eslint.org/docs/latest/use/configure/configuration-files#globally-ignoring-files-with-ignores
-    ignores: ["**/dist"]
+    ignores: ["**/dist", "eslint.config.js"]
   },
   {
     rules: {
       // Rules disabled as part of migration from tslint
       // https://github.com/Azure/openapi-diff/pull/335
-      "@typescript-eslint/no-explicit-any": "off",
+      // kja turned off to check if it works in CI
+      // "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-unnecessary-type-assertion": "off",
       "@typescript-eslint/no-unsafe-argument": "off",
       "@typescript-eslint/no-unsafe-assignment": "off",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/oad",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",
@@ -8,7 +8,6 @@
   },
   "description": "OpenApi Specification Diff tool",
   "license": "MIT",
-  "type": "module",
   "dependencies": {
     "@ts-common/fs": "^0.2.0",
     "@ts-common/iterator": "^0.3.6",


### PR DESCRIPTION
See comments in the diff for details, as well as:

- https://github.com/Azure/openapi-diff/pull/335/files#r1649413983

Proof it still lints:
- https://dev.azure.com/azure-sdk/public/_build/results?buildId=3895699&view=logs&j=1c4c5c28-f36b-5682-1755-6ce7d2834f88&t=0b5d541a-0099-500c-3fd6-3782f2951919