### PR TITLE
Fix NRE in CompareRequired

### DIFF
--- a/openapi-diff/src/modeler/AutoRest.Swagger/Model/Schema.cs
+++ b/openapi-diff/src/modeler/AutoRest.Swagger/Model/Schema.cs
@@ -213,14 +213,16 @@ namespace AutoRest.Swagger.Model
             var newRequiredNonReadOnlyPropNames = new List<string>();
             foreach (string requiredPropName in Required)
             {
-                Properties.TryGetValue(requiredPropName, out Schema propSchema);
-                priorSchema.Properties.TryGetValue(requiredPropName, out Schema priorPropSchema);
-                bool propWasRequired = priorSchema.Required?.Contains(requiredPropName) == true;
+                Schema propSchema = null;
+                Schema priorPropSchema = null;
+                Properties?.TryGetValue(requiredPropName, out propSchema);
+                priorSchema?.Properties?.TryGetValue(requiredPropName, out priorPropSchema);
+                bool propWasRequired = priorSchema?.Required?.Contains(requiredPropName) == true;
                 // Note that property is considered read-only only if it is consistently read-only both in the old and new models.
                 bool propIsReadOnly = propSchema?.ReadOnly == true && priorPropSchema?.ReadOnly == true;
                 if (!propWasRequired && !propIsReadOnly)
                 {
-                    // Property is newly required and it is not read-only, hence it is a breaking change.
+                    // Property is newly required, and it is not read-only, hence it is a breaking change.
                     newRequiredNonReadOnlyPropNames.Add(requiredPropName);
                 }
                 else

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/oad",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
Fixes errors like this one:

- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3975850&view=logs&j=98f87804-8e1f-5655-af02-e80aefa7aa97&t=65457206-7ab6-5966-2a2f-9ae3efa14a03&l=54
- https://github.com/Azure/azure-rest-api-specs/pull/29918/checks?check_run_id=27647800156

![image](https://github.com/user-attachments/assets/06cc1064-1ec0-435a-a483-db8da3ab8894)

```
Command failed: dotnet \"/mnt/vss/_work/_tasks/AzureApiValidation_5654d05d-82c1-48da-ad8f-161b817f6d41/0.0.111/common/temp/node_modules/.pnpm/@azure+oad@0.10.12/node_modules/@azure/oad/dlls/OpenApiDiff.dll\" -o /tmp/oad-9EHgIA/old-resolved.json -n /tmp/oad-OSxSXz/new-resolved.json
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at AutoRest.Swagger.Model.Schema.CompareRequired(ComparisonContext`1 context, Schema priorSchema) in D:\\a\\_work\\1\\s\\openapi-diff\\src\\modeler\\AutoRest.Swagger\\Model\\Schema.cs:line 214
   at AutoRest.Swagger.Model.Schema.Compare(ComparisonContext`1 context, Schema previous) in D:\\a\\_work\\1\\s\\openapi-diff\\src\\modeler\\AutoRest.Swagger\\Model\\Schema.cs:line 181
   at AutoRest.Swagger.Model.Schema.CompareProperties(ComparisonContext`1 context, Schema priorSchema) in D:\\a\\_work\\1\\s\\openapi-diff\\src\\modeler\\AutoRest.Swagger\\Model\\Schema.cs:line 270
   at AutoRest.Swagger.Model.Schema.Compare(ComparisonContext`1 context, Schema previous)
```