### PR TITLE
Support Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6'
+          dotnet-version: "6"
 
       - name: test
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,9 @@ jobs:
       - name: prettier
         run: npm run prettier
 
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '6'
+
       - name: test
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,17 @@ jobs:
         include:
           - os: ubuntu-latest
             target-folder: drop-linux
+            node-version: 18.x
           - os: windows-latest
             target-folder: drop
+            node-version: 22.x
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ matrix.node-version }}
 
       - name: npm ci
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
         include:
           - os: ubuntu-latest
             target-folder: drop-linux
-            node-version: 18.x
+            node-version: 22.x
           - os: windows-latest
             target-folder: drop
-            node-version: 22.x
+            node-version: 18.x
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Failing with:

```
    (node:3389) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
    (Use `node --trace-deprecation ...` to show where the warning was created)
```