### PR TITLE
Use authenticated npmrc

### DIFF
--- a/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+++ b/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
@@ -1,0 +1,41 @@
+parameters:
+  - name: npmrcPath
+    type: string
+    # When empty, defaults to the agent user's .npmrc ($HOME/.npmrc on
+    # Linux/macOS, %USERPROFILE%\.npmrc on Windows) so every subsequent
+    # npm / pnpm / npx call in the job inherits the registry + auth.
+    default: ""
+  - name: registryUrl
+    type: string
+    default: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/"
+  - name: CustomCondition
+    type: string
+    default: succeeded()
+  - name: ServiceConnection
+    type: string
+    default: ""
+
+steps:
+  - pwsh: |
+      $npmrcPath = '${{ parameters.npmrcPath }}'
+      if (-not $npmrcPath) { $npmrcPath = Join-Path $HOME '.npmrc' }
+
+      Write-Host "Creating .npmrc file $npmrcPath for registry ${{ parameters.registryUrl }}"
+      $parentFolder = Split-Path -Path $npmrcPath -Parent
+
+      if ($parentFolder -and -not (Test-Path $parentFolder)) {
+        Write-Host "Creating folder $parentFolder"
+        New-Item -Path $parentFolder -ItemType Directory | Out-Null
+      }
+
+      "registry=${{ parameters.registryUrl }}" | Out-File $npmrcPath
+      Write-Host "##vso[task.setvariable variable=resolvedNpmrcPath]$npmrcPath"
+    displayName: "Create .npmrc"
+    condition: ${{ parameters.CustomCondition }}
+
+  - task: npmAuthenticate@0
+    displayName: Authenticate .npmrc
+    condition: ${{ parameters.CustomCondition }}
+    inputs:
+      workingFile: $(resolvedNpmrcPath)
+      azureDevOpsServiceConnection: ${{ parameters.ServiceConnection }}

--- a/eng/test-steps.yml
+++ b/eng/test-steps.yml
@@ -8,12 +8,8 @@ steps:
     inputs:
       version: 6.x
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-    parameters:
-      npmrcPath: $(Agent.TempDirectory)/test/.npmrc
   - script: npm ci
     displayName: npm ci
-    env:
-      npm_config_userconfig: "$(Agent.TempDirectory)/test/.npmrc"
   - script: npm run lint
     displayName: lint
   - script: npm run prettier

--- a/eng/test-steps.yml
+++ b/eng/test-steps.yml
@@ -7,8 +7,13 @@ steps:
   - task: UseDotNet@2
     inputs:
       version: 6.x
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: $(Agent.TempDirectory)/test/.npmrc
   - script: npm ci
     displayName: npm ci
+    env:
+      npm_config_userconfig: "$(Agent.TempDirectory)/test/.npmrc"
   - script: npm run lint
     displayName: lint
   - script: npm run prettier


### PR DESCRIPTION
This pull request updates the test pipeline configuration to improve npm authentication during test steps. The main change is the addition of a step to create an authenticated `.npmrc` file, ensuring npm commands use the correct credentials.

**Pipeline authentication improvements:**

* Added a step to generate an authenticated `.npmrc` file for npm commands by including the `create-authenticated-npmrc.yml` template and specifying the path as `$(Agent.TempDirectory)/test/.npmrc`.
* Updated the `npm ci` step to use the custom `.npmrc` file by setting the `npm_config_userconfig` environment variable.

[openapi-diff](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6467760&view=results)