### PR TITLE
Add Nuget config trageting devOps feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- Do not add any additional feeds if new packages are needed they need to come from our azure-sdk-for-net DevOps feed which has an upstream set to nuget.org -->
+    <add key="azure-sdk-for-net" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/eng/test-steps.yml
+++ b/eng/test-steps.yml
@@ -4,6 +4,7 @@ parameters:
     default: "drop"
 
 steps:
+  - task: NuGetAuthenticate@1
   - task: UseDotNet@2
     inputs:
       version: 6.x


### PR DESCRIPTION
This pull request introduces changes to standardize and secure the use of NuGet package sources for .NET builds and tests. The main improvements are the enforcement of a single, approved package source and the explicit authentication step for Azure DevOps pipelines. These changes help ensure that dependencies are only pulled from trusted locations.

**NuGet package source enforcement:**

* Added a `NuGet.Config` file that restricts package sources to the `azure-sdk-for-net` feed, preventing the use of unauthorized feeds and ensuring all dependencies are resolved from a controlled source.
* Updated `dn.clean` and `dn.restore` scripts in `package.json` to use the new `NuGet.config` file, enforcing the package source restrictions during restore and clean operations.

**Pipeline authentication improvements:**

* Added a `NuGetAuthenticate@1` task in `eng/test-steps.yml` to ensure authenticated access to the Azure DevOps package feed during CI/CD builds and tests.