### PR TITLE
Enforce CFSClean for Network Isolation

### DIFF
--- a/eng/1es-redirect.yml
+++ b/eng/1es-redirect.yml
@@ -36,6 +36,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: Permissive, CFSClean
     sdl:
       git:
         longpaths: true

--- a/eng/test-steps.yml
+++ b/eng/test-steps.yml
@@ -8,17 +8,30 @@ steps:
   - task: UseDotNet@2
     inputs:
       version: 6.x
+      
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: $(Agent.TempDirectory)/oad.npmrc
+  
   - script: npm ci
     displayName: npm ci
+    env:
+      NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/oad.npmrc
+
   - script: npm run lint
     displayName: lint
+
   - script: npm run prettier
     displayName: prettier
+
   - script: npm test
     displayName: test
+    env:
+      NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/oad.npmrc
+
   - script: npm pack
     displayName: pack
+    
   - task: CopyFiles@2
     displayName: "Copy Files to Staging"
     inputs:

--- a/eng/test-steps.yml
+++ b/eng/test-steps.yml
@@ -28,9 +28,12 @@ steps:
     displayName: test
     env:
       NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/oad.npmrc
+      autorest_registry: https://packagefeedproxy.microsoft.io/npm/
 
   - script: npm pack
     displayName: pack
+    env:
+      NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/oad.npmrc
 
   - task: CopyFiles@2
     displayName: "Copy Files to Staging"

--- a/eng/test-steps.yml
+++ b/eng/test-steps.yml
@@ -8,11 +8,11 @@ steps:
   - task: UseDotNet@2
     inputs:
       version: 6.x
-      
+
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
     parameters:
       npmrcPath: $(Agent.TempDirectory)/oad.npmrc
-  
+
   - script: npm ci
     displayName: npm ci
     env:
@@ -31,7 +31,7 @@ steps:
 
   - script: npm pack
     displayName: pack
-    
+
   - task: CopyFiles@2
     displayName: "Copy Files to Staging"
     inputs:

--- a/src/lib/validators/openApiDiff.ts
+++ b/src/lib/validators/openApiDiff.ts
@@ -24,6 +24,11 @@ const getAutoRestNpmrcPath = (): string | undefined => {
   return candidates.find(value => typeof value === "string" && value.trim().length > 0)
 }
 
+const getAutoRestCoreVersion = (): string => {
+  const configuredVersion = process.env.OAD_AUTOREST_CORE_VERSION?.trim()
+  return configuredVersion?.length ? configuredVersion : "3.10.9"
+}
+
 export type Options = {
   readonly consoleLogLevel?: unknown
   readonly logFilepath?: unknown
@@ -237,8 +242,10 @@ export class OpenApiDiff {
 
     const swaggerArgs = tagName ? [swaggerPath, `--tag=${tagName}`] : [`--input-file=${swaggerPath}`]
 
+    const autoRestCoreVersion = getAutoRestCoreVersion()
+
     const commonArgs = [
-      "--v2",
+      `--version=${autoRestCoreVersion}`,
       "--output-artifact=swagger-document.json",
       "--output-artifact=swagger-document.map",
       `--output-file=${outputFileName}`,
@@ -250,12 +257,13 @@ export class OpenApiDiff {
     const env = {
       ...process.env,
       NODE_OPTIONS: "--max-old-space-size=8192",
-      ...(autoRestNpmrcPath ? { npm_config_userconfig: autoRestNpmrcPath } : {})
+      ...(autoRestNpmrcPath ? { npm_config_userconfig: autoRestNpmrcPath, NPM_CONFIG_USERCONFIG: autoRestNpmrcPath } : {})
     }
 
     if (autoRestNpmrcPath) {
       log.debug(`Using npm user config for AutoRest: ${autoRestNpmrcPath}`)
     }
+    log.debug(`Using AutoRest core version: ${autoRestCoreVersion}`)
 
     log.debug(`Executing: "${autoRestFile} ${args.join(" ")}"`)
 

--- a/src/lib/validators/openApiDiff.ts
+++ b/src/lib/validators/openApiDiff.ts
@@ -19,6 +19,11 @@ const _ = require("lodash")
 
 const execFile = util.promisify(child_process.execFile)
 
+const getAutoRestNpmrcPath = (): string | undefined => {
+  const candidates = [process.env.npm_config_userconfig, process.env.NPM_CONFIG_USERCONFIG]
+  return candidates.find(value => typeof value === "string" && value.trim().length > 0)
+}
+
 export type Options = {
   readonly consoleLogLevel?: unknown
   readonly logFilepath?: unknown
@@ -241,13 +246,23 @@ export class OpenApiDiff {
     ]
 
     const args = [...autoRestArgs, ...swaggerArgs, ...commonArgs]
+    const autoRestNpmrcPath = getAutoRestNpmrcPath()
+    const env = {
+      ...process.env,
+      NODE_OPTIONS: "--max-old-space-size=8192",
+      ...(autoRestNpmrcPath ? { npm_config_userconfig: autoRestNpmrcPath } : {})
+    }
+
+    if (autoRestNpmrcPath) {
+      log.debug(`Using npm user config for AutoRest: ${autoRestNpmrcPath}`)
+    }
 
     log.debug(`Executing: "${autoRestFile} ${args.join(" ")}"`)
 
     const { stderr } = await execFile(autoRestFile, args, {
       encoding: "utf8",
       maxBuffer: 1024 * 1024 * 64,
-      env: { ...process.env, NODE_OPTIONS: "--max-old-space-size=8192" }
+      env
     })
     if (stderr) {
       // autorest 3.8.0 emits deprecation message to stderr with exit code 0

--- a/src/lib/validators/openApiDiff.ts
+++ b/src/lib/validators/openApiDiff.ts
@@ -24,9 +24,24 @@ const getAutoRestNpmrcPath = (): string | undefined => {
   return candidates.find(value => typeof value === "string" && value.trim().length > 0)
 }
 
-const getAutoRestCoreVersion = (): string => {
-  const configuredVersion = process.env.OAD_AUTOREST_CORE_VERSION?.trim()
-  return configuredVersion?.length ? configuredVersion : "3.10.9"
+export const getAutoRestRegistry = (npmrcPath = getAutoRestNpmrcPath()): string | undefined => {
+  const configuredRegistry = [process.env.autorest_registry, process.env.npm_config_registry, process.env.NPM_CONFIG_REGISTRY].find(
+    value => typeof value === "string" && value.trim().length > 0
+  )
+  if (configuredRegistry) {
+    return configuredRegistry.trim()
+  }
+
+  if (!npmrcPath || !fs.existsSync(npmrcPath)) {
+    return undefined
+  }
+
+  const registryEntry = fs
+    .readFileSync(npmrcPath, "utf8")
+    .split(/\r?\n/u)
+    .map(line => line.match(/^\s*registry\s*=\s*["']?([^"'#;]+)["']?\s*(?:[#;].*)?$/iu)?.[1]?.trim())
+    .find(value => value)
+  return registryEntry
 }
 
 export type Options = {
@@ -242,10 +257,8 @@ export class OpenApiDiff {
 
     const swaggerArgs = tagName ? [swaggerPath, `--tag=${tagName}`] : [`--input-file=${swaggerPath}`]
 
-    const autoRestCoreVersion = getAutoRestCoreVersion()
-
     const commonArgs = [
-      `--version=${autoRestCoreVersion}`,
+      "--v2",
       "--output-artifact=swagger-document.json",
       "--output-artifact=swagger-document.map",
       `--output-file=${outputFileName}`,
@@ -254,16 +267,20 @@ export class OpenApiDiff {
 
     const args = [...autoRestArgs, ...swaggerArgs, ...commonArgs]
     const autoRestNpmrcPath = getAutoRestNpmrcPath()
+    const autoRestRegistry = getAutoRestRegistry(autoRestNpmrcPath)
     const env = {
       ...process.env,
       NODE_OPTIONS: "--max-old-space-size=8192",
-      ...(autoRestNpmrcPath ? { npm_config_userconfig: autoRestNpmrcPath, NPM_CONFIG_USERCONFIG: autoRestNpmrcPath } : {})
+      ...(autoRestNpmrcPath ? { npm_config_userconfig: autoRestNpmrcPath, NPM_CONFIG_USERCONFIG: autoRestNpmrcPath } : {}),
+      ...(autoRestRegistry ? { autorest_registry: autoRestRegistry } : {})
     }
 
     if (autoRestNpmrcPath) {
       log.debug(`Using npm user config for AutoRest: ${autoRestNpmrcPath}`)
     }
-    log.debug(`Using AutoRest core version: ${autoRestCoreVersion}`)
+    if (autoRestRegistry) {
+      log.debug(`Using npm registry for AutoRest core: ${autoRestRegistry}`)
+    }
 
     log.debug(`Executing: "${autoRestFile} ${args.join(" ")}"`)
 

--- a/src/test/openApiDiffTest.ts
+++ b/src/test/openApiDiffTest.ts
@@ -1,0 +1,31 @@
+import * as assert from "assert"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { getAutoRestRegistry } from "../lib/validators/openApiDiff"
+
+describe("OpenApiDiff", () => {
+  it("gets the AutoRest core registry from the npm user config", () => {
+    const tempFolder = fs.mkdtempSync(path.join(os.tmpdir(), "oad-npmrc-"))
+    const npmrcPath = path.join(tempFolder, ".npmrc")
+    fs.writeFileSync(npmrcPath, "@azure:registry=https://example.invalid/scoped/\nregistry=https://packagefeedproxy.microsoft.io/npm/\n")
+
+    const environmentVariables = ["autorest_registry", "npm_config_registry", "NPM_CONFIG_REGISTRY"] as const
+    const originalValues = environmentVariables.map(name => process.env[name])
+    environmentVariables.forEach(name => delete process.env[name])
+
+    try {
+      assert.equal(getAutoRestRegistry(npmrcPath), "https://packagefeedproxy.microsoft.io/npm/")
+    } finally {
+      environmentVariables.forEach((name, index) => {
+        const originalValue = originalValues[index]
+        if (originalValue === undefined) {
+          delete process.env[name]
+        } else {
+          process.env[name] = originalValue
+        }
+      })
+      fs.rmSync(tempFolder, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
This pull request introduces a configuration update to the `eng/1es-redirect.yml` file. The main change is the addition of a more permissive network isolation policy.

Pipeline configuration:

* Added `networkIsolationPolicy: Permissive, CFSClean` to the pipeline settings to allow broader network access during builds.